### PR TITLE
Fix compound reset button

### DIFF
--- a/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantRemoveOne.java
+++ b/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantRemoveOne.java
@@ -65,7 +65,9 @@ public class RequestNewEnchantRemoveOne extends ClientPacket {
             return;
         }
         request.setItemOne(0);
-
+        if (request.getItemTwo() == null) {
+            activeChar.removeRequest(request.getClass());
+        }
         client.sendPacket(ExEnchantOneRemoveOK.STATIC_PACKET);
     }
 }

--- a/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantRemoveTwo.java
+++ b/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantRemoveTwo.java
@@ -65,6 +65,8 @@ public class RequestNewEnchantRemoveTwo extends ClientPacket {
             return;
         }
         request.setItemTwo(0);
+        
+        activeChar.removeRequest(request.getClass());
 
         client.sendPacket(ExEnchantTwoRemoveOK.STATIC_PACKET);
     }

--- a/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantTry.java
+++ b/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/compound/RequestNewEnchantTry.java
@@ -90,7 +90,10 @@ public class RequestNewEnchantTry extends ClientPacket {
 
         final InventoryUpdate iu = new InventoryUpdate();
         iu.addRemovedItem(itemOne);
-        iu.addRemovedItem(itemTwo);
+
+        if (!itemTwo.isStackable()) {
+            iu.addRemovedItem(itemTwo);
+        }
 
         if (activeChar.destroyItem("Compound-Item-One", itemOne, 1, null, true) && activeChar.destroyItem("Compound-Item-Two", itemTwo, 1, null, true)) {
             final double random = (Rnd.nextDouble() * 100);

--- a/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/teleport/ExRequestTeleport.java
+++ b/Gameserver/src/main/org.l2j.gameserver/org/l2j/gameserver/network/clientpackets/teleport/ExRequestTeleport.java
@@ -18,6 +18,7 @@
  */
 package org.l2j.gameserver.network.clientpackets.teleport;
 
+import org.l2j.gameserver.Config;
 import org.l2j.gameserver.data.xml.impl.TeleportEngine;
 import org.l2j.gameserver.data.xml.model.TeleportData;
 import org.l2j.gameserver.instancemanager.CastleManager;


### PR DESCRIPTION
When click reset button on client you can’t add item to compound. This
commit fix that problem